### PR TITLE
Fix tree visualization controls and add dropdown tree selector

### DIFF
--- a/src/lib/PhylogeneticTreeViewer.svelte
+++ b/src/lib/PhylogeneticTreeViewer.svelte
@@ -41,7 +41,7 @@
 
 	afterUpdate(() => {
 		const newick = getTreeNewick(data, treeIndex);
-		const currentDataKey = `${JSON.stringify(data)}-${treeIndex}-${colorBranches}-${branchLengthProperty}`;
+		const currentDataKey = `${JSON.stringify(data)}-${treeIndex}-${colorBranches}-${branchLengthProperty}-${width}-${height}`;
 
 		if (
 			newick &&
@@ -267,7 +267,7 @@
 		}
 
 		isRendering = true;
-		const currentDataKey = `${JSON.stringify(data)}-${treeIndex}-${colorBranches}-${branchLengthProperty}`;
+		const currentDataKey = `${JSON.stringify(data)}-${treeIndex}-${colorBranches}-${branchLengthProperty}-${width}-${height}`;
 
 		try {
 			// Make sure we have a valid Newick string

--- a/src/lib/PhylogeneticTreeViewer.svelte
+++ b/src/lib/PhylogeneticTreeViewer.svelte
@@ -28,6 +28,9 @@
 
 	const dispatch = createEventDispatcher();
 
+	// Get available trees
+	$: availableTrees = getAvailableTrees(data);
+
 	// Force re-render when colorScale or colorRange changes
 	$: legendVisible = !!(
 		colorScale &&
@@ -70,6 +73,34 @@
 		}
 
 		return null;
+	}
+
+	function getAvailableTrees(data) {
+		if (!data?.input?.trees) return [];
+
+		const trees = data.input.trees;
+
+		if (Array.isArray(trees)) {
+			// For array format, return indices with labels
+			return trees.map((_, index) => ({
+				value: index,
+				label: `Tree ${index + 1}`
+			}));
+		} else if (typeof trees === "object") {
+			// For object format, use the keys as labels
+			return Object.keys(trees).map((key, index) => ({
+				value: index,
+				label: key
+			}));
+		} else if (typeof trees === "string") {
+			// Single tree
+			return [{
+				value: 0,
+				label: "Tree 1"
+			}];
+		}
+
+		return [];
 	}
 
 	function getBranchAttributes(data, treeIndex = 0) {
@@ -426,16 +457,16 @@
 		<div class="loading">No tree data provided</div>
 	{:else}
 		<div class="controls">
-			<div class="control-group">
-				<label for="tree-index">Tree:</label>
-				<input
-					id="tree-index"
-					type="number"
-					bind:value={treeIndex}
-					min="0"
-					max="10"
-				/>
-			</div>
+			{#if availableTrees.length > 1}
+				<div class="control-group">
+					<label for="tree-select">Tree:</label>
+					<select id="tree-select" bind:value={treeIndex}>
+						{#each availableTrees as tree}
+							<option value={tree.value}>{tree.label}</option>
+						{/each}
+					</select>
+				</div>
+			{/if}
 
 			<div class="control-group">
 				<label for="color-branches">Color branches:</label>

--- a/src/stories/data/fel-test-data.ts
+++ b/src/stories/data/fel-test-data.ts
@@ -45,7 +45,8 @@ export const felTestData = {
     "file name": "sample.fas",
     "number of sequences": 8,
     "number of sites": 10,
-    "partition count": 1
+    "partition count": 1,
+    "trees": "(Cow:0.11,((Raccoon:0.08,Bear:0.05):0.03,(((Monkey:0.02,Cat:0.03):0.01,Weasel:0.04):0.02,(Dog:0.05,Seal:0.06):0.01):0.02):0.01,Horse:0.08);"
   },
   "test results": {
     "P-value threshold": 0.1,

--- a/src/stories/data/fel-test-data.ts
+++ b/src/stories/data/fel-test-data.ts
@@ -46,7 +46,11 @@ export const felTestData = {
     "number of sequences": 8,
     "number of sites": 10,
     "partition count": 1,
-    "trees": "(Cow:0.11,((Raccoon:0.08,Bear:0.05):0.03,(((Monkey:0.02,Cat:0.03):0.01,Weasel:0.04):0.02,(Dog:0.05,Seal:0.06):0.01):0.02):0.01,Horse:0.08);"
+    "trees": {
+      "Original tree": "(Cow:0.11,((Raccoon:0.08,Bear:0.05):0.03,(((Monkey:0.02,Cat:0.03):0.01,Weasel:0.04):0.02,(Dog:0.05,Seal:0.06):0.01):0.02):0.01,Horse:0.08);",
+      "Alternative topology": "((Cow:0.10,Horse:0.08):0.02,(Raccoon:0.08,(Bear:0.05,((Monkey:0.02,Cat:0.03):0.01,(Weasel:0.04,(Dog:0.05,Seal:0.06):0.01):0.02):0.02):0.03):0.01);",
+      "Rerooted tree": "(Horse:0.08,(Cow:0.11,((Raccoon:0.08,Bear:0.05):0.03,(((Monkey:0.02,Cat:0.03):0.01,Weasel:0.04):0.02,(Dog:0.05,Seal:0.06):0.01):0.02):0.01):0.00);"
+    }
   },
   "test results": {
     "P-value threshold": 0.1,

--- a/src/stories/data/meme-test-data.ts
+++ b/src/stories/data/meme-test-data.ts
@@ -45,7 +45,8 @@ export const memeTestData = {
     "file name": "sample.fas",
     "number of sequences": 8,
     "number of sites": 10,
-    "partition count": 1
+    "partition count": 1,
+    "trees": "(Cow:0.11,((Raccoon:0.08,Bear:0.05):0.03,(((Monkey:0.02,Cat:0.03):0.01,Weasel:0.04):0.02,(Dog:0.05,Seal:0.06):0.01):0.02):0.01,Horse:0.08);"
   },
   "test results": {
     "P-value threshold": 0.1,


### PR DESCRIPTION
## Summary
- Fixed tree size controls that weren't updating on dimension changes in PhylogeneticTreeViewer
- Added missing tree data to FEL and MEME storybook test data to fix "No tree data found" errors
- Replaced indefinite tree index number input with intuitive dropdown selector showing all available trees

## Changes Made
- Updated PhylogeneticTreeViewer.svelte to track width/height changes in re-render logic
- Added sample Newick trees to fel-test-data.ts and meme-test-data.ts for proper testing
- Implemented getAvailableTrees() function to handle different tree storage formats
- Added conditional dropdown that only shows when multiple trees are available
- Enhanced tree selection with meaningful labels instead of just indices

## Test plan
- [x] Verified tree size controls now respond to width/height slider changes
- [x] Confirmed FEL and MEME visualizations show tree data in storybook
- [x] Tested tree dropdown selector with multiple trees
- [x] Verified backwards compatibility with single tree datasets

🤖 Generated with [Claude Code](https://claude.ai/code)