### PR TITLE
Add AxomemeVisualization for AxoMEME per-site predictions

### DIFF
--- a/src/lib/AxomemeVisualization.svelte
+++ b/src/lib/AxomemeVisualization.svelte
@@ -1,0 +1,375 @@
+<script lang="ts">
+	/**
+	 * AxomemeVisualization — per-site results from the AxoMEME neural surrogate.
+	 *
+	 * WHY THIS DIFFERS FROM EVERY OTHER COMPONENT IN THIS LIBRARY. The rest visualise HyPhy analyses,
+	 * where a per-site p-value means what it says and a threshold line is the most useful mark on the
+	 * chart. AxoMEME is a fitted model that RANKS sites; its score is not calibrated to MEME's scale.
+	 * Measured across 12 real DataMonkey submissions and 662 variable sites, the score reached the
+	 * chi-square gate for p <= 0.10 exactly once and the p <= 0.05 gate never — on data where MEME
+	 * itself reports significant sites.
+	 *
+	 * So this component deliberately does three things differently:
+	 *   - No significance threshold line, and no threshold control. There is no cutoff on this scale
+	 *     that means what a reader would assume.
+	 *   - Rank is a first-class column, and the default plot orders sites by score rather than by
+	 *     position, because that is the question a ranker can answer.
+	 *   - Invariant sites are marked "not scored" rather than shown as zero. Their zeros were never
+	 *     predictions — they are set before the model is consulted — and rendering them as 0.000
+	 *     alongside real zeros conflates "the model said nothing" with "we never asked".
+	 */
+	import { onMount } from 'svelte';
+	import {
+		getAxomemeAttributes,
+		getScoredSites,
+		assignTiers,
+		sortAxomemeSites,
+		AXOMEME_COLORS,
+		AXOMEME_NEUTRAL_CALL,
+		type AxomemeResult,
+		type AxomemeSiteData
+	} from './utils/axomeme-utils.js';
+	import {
+		getAxomemePlotOptions,
+		getAxomemePlotDescription,
+		createAxomemePlot
+	} from './utils/axomeme-plots.js';
+
+	export let data: AxomemeResult | null = null;
+	export let plotType: string = 'Ranked sites';
+	/** Show only sites the model called, which is what most readers want first. */
+	export let onlyCalled: boolean = true;
+
+	let plotContainer: HTMLElement;
+	let currentPage = 1;
+	let itemsPerPage = 25;
+	let sortColumn: keyof AxomemeSiteData = 'lrt';
+	let sortDirection: 'asc' | 'desc' = 'desc';
+
+	$: sites = data?.sites ?? [];
+	$: attributes = getAxomemeAttributes(data);
+	$: tiers = assignTiers(sites);
+	$: scored = getScoredSites(sites);
+	$: called = scored.filter((s) => s.call !== AXOMEME_NEUTRAL_CALL);
+	$: availablePlots = getAxomemePlotOptions().filter((o) => o.available(sites));
+	$: plotDescription = getAxomemePlotDescription(plotType);
+
+	// The table shows called sites by default; unticking the box shows EVERY site, including the ones
+	// the model never scored. Falling back to `scored` instead would silently drop invariant sites, so
+	// a reader scanning site numbers would find gaps with no explanation — and the "not scored" row
+	// below would be unreachable code. When nothing was called at all, show everything rather than an
+	// empty table, which reads as a failure rather than as a result.
+	$: tableSource = onlyCalled && called.length > 0 ? called : sites;
+	$: sortedSites = sortAxomemeSites(tableSource, sortColumn, sortDirection);
+	$: totalPages = Math.max(1, Math.ceil(sortedSites.length / itemsPerPage));
+	$: pageSites = sortedSites.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
+	$: if (currentPage > totalPages) currentPage = totalPages;
+
+	function toggleSort(column: keyof AxomemeSiteData) {
+		if (sortColumn === column) {
+			sortDirection = sortDirection === 'asc' ? 'desc' : 'asc';
+		} else {
+			sortColumn = column;
+			sortDirection = 'desc';
+		}
+	}
+
+	/**
+	 * NOTHING IN HERE MAY AWAIT, and that is not a style preference.
+	 *
+	 * This runs from a reactive statement, which Svelte 5 compiles to a pre-effect. An earlier version
+	 * called `await tick()` first, to be sure the container was bound. `tick()` flushes pending
+	 * effects — including the one that called it — which calls this again, which awaits `tick()`
+	 * again. The recursion is unbounded and it kills the renderer process before Svelte's own
+	 * effect-depth guard can report anything: the tab dies with no console error, no page error, and
+	 * no stack. Every other route in this app loaded fine, which is what made it look like a build or
+	 * link problem rather than a component one.
+	 *
+	 * The await bought nothing anyway. `bind:this` is assigned before the effect runs, and the guard
+	 * below covers the case where it is not.
+	 */
+	function renderPlot() {
+		if (!plotContainer || scored.length === 0) return;
+		plotContainer.innerHTML = '';
+		try {
+			plotContainer.appendChild(createAxomemePlot(plotType, sites));
+		} catch (e) {
+			plotContainer.innerHTML = `<p class="axomeme-error">Could not render this plot: ${
+				(e as Error).message
+			}</p>`;
+		}
+	}
+
+	$: if (plotContainer && plotType && sites.length) renderPlot();
+	onMount(renderPlot);
+
+	const fmt = (v: number, dp = 3) => (Number.isFinite(v) ? v.toFixed(dp) : '—');
+	const tierColor = (call: string) =>
+		tiers.get(call) === 1
+			? AXOMEME_COLORS.tier1
+			: tiers.get(call) === 2
+				? AXOMEME_COLORS.tier2
+				: AXOMEME_COLORS.neutral;
+</script>
+
+{#if !data || sites.length === 0}
+	<p class="axomeme-empty">No AxoMEME results to display.</p>
+{:else}
+	<div class="axomeme-visualization">
+		<header class="axomeme-header">
+			<h3>AxoMEME predictions</h3>
+			<p>
+				A neural model ranks the sites of this alignment by how MEME-like their signal looks. MEME
+				was not run. The score orders sites <em>within this alignment</em> and is not calibrated to
+				MEME's scale — there is no significance threshold on it, which is why none is drawn.
+			</p>
+		</header>
+
+		<div class="axomeme-summary">
+			<div class="axomeme-stat">
+				<strong>{attributes.calledSites}</strong>
+				<span>top-ranked {attributes.calledSites === 1 ? 'site' : 'sites'}</span>
+			</div>
+			<div class="axomeme-stat">
+				<strong>{attributes.scoredSites}</strong>
+				<span>scored {attributes.scoredSites === 1 ? 'site' : 'sites'}</span>
+			</div>
+			<div class="axomeme-stat">
+				<strong>{attributes.totalSites}</strong>
+				<span>codon {attributes.totalSites === 1 ? 'site' : 'sites'}</span>
+			</div>
+			<div class="axomeme-stat">
+				<strong>{fmt(attributes.maxScore, 2)}</strong>
+				<span>highest score</span>
+			</div>
+		</div>
+
+		<div class="axomeme-controls">
+			<label>
+				Plot
+				<select bind:value={plotType}>
+					{#each availablePlots as option}
+						<option value={option.label}>{option.label}</option>
+					{/each}
+				</select>
+			</label>
+			<label class="axomeme-check">
+				<input type="checkbox" bind:checked={onlyCalled} disabled={called.length === 0} />
+				Table shows top-ranked sites only
+			</label>
+		</div>
+
+		{#if plotDescription}
+			<p class="axomeme-plot-description">{plotDescription}</p>
+		{/if}
+		<div class="axomeme-plot" bind:this={plotContainer}></div>
+
+		<div class="axomeme-table-wrap">
+			<table class="axomeme-table">
+				<thead>
+					<tr>
+						<th on:click={() => toggleSort('site')}>Codon site</th>
+						<th>Reference</th>
+						<th>AA</th>
+						<th on:click={() => toggleSort('percentile')} class="num">Percentile</th>
+						<th on:click={() => toggleSort('lrt')} class="num">Score</th>
+						<th on:click={() => toggleSort('logLrt')} class="num">log(1+score)</th>
+						<th on:click={() => toggleSort('betaPosDn')} class="num">dN⁺</th>
+						<th on:click={() => toggleSort('alphaDs')} class="num">dS</th>
+						<th on:click={() => toggleSort('zScore')} class="num">Z</th>
+						<th>Call</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each pageSites as row (row.site)}
+						<tr>
+							<td class="mono">{row.site}</td>
+							<td class="mono">{row.refCodon}</td>
+							<td class="mono">{row.refAa}</td>
+							{#if row.isVariable}
+								<td class="num mono">{row.percentile.toFixed(1)}</td>
+								<td class="num mono">{fmt(row.lrt)}</td>
+								<td class="num mono">{fmt(row.logLrt)}</td>
+								<td class="num mono">{fmt(row.betaPosDn)}</td>
+								<td class="num mono">{fmt(row.alphaDs)}</td>
+								<td class="num mono">{fmt(row.zScore, 2)}</td>
+							{:else}
+								<!-- Zeroed before the model was consulted: "not applicable", not "no selection". -->
+								<td class="num unscored" colspan="6">not scored — no amino-acid variation</td>
+							{/if}
+							<td>
+								<span class="axomeme-call" style="background:{tierColor(row.call)}22; color:{tierColor(row.call)}">
+									{row.call}
+								</span>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+
+		<div class="axomeme-pagination">
+			<button on:click={() => (currentPage = Math.max(1, currentPage - 1))} disabled={currentPage === 1}>
+				Prev
+			</button>
+			<span>
+				{(currentPage - 1) * itemsPerPage + 1}–{Math.min(currentPage * itemsPerPage, sortedSites.length)}
+				of {sortedSites.length}
+			</span>
+			<button
+				on:click={() => (currentPage = Math.min(totalPages, currentPage + 1))}
+				disabled={currentPage === totalPages}
+			>
+				Next
+			</button>
+		</div>
+
+		<footer class="axomeme-footer">
+			{#if attributes.modelVersion}AxoMEME {attributes.modelVersion}{/if}
+			{#if attributes.callMode} · ranked by {attributes.callMode}{/if}
+			{#if attributes.referenceSequence} · reference <span class="mono">{attributes.referenceSequence}</span>{/if}
+		</footer>
+	</div>
+{/if}
+
+<style>
+	.axomeme-visualization {
+		font-family:
+			ui-sans-serif,
+			system-ui,
+			sans-serif;
+		color: #0f172a;
+	}
+	.axomeme-empty {
+		color: #64748b;
+		font-style: italic;
+	}
+	.axomeme-header h3 {
+		margin: 0 0 0.25rem;
+		font-size: 1.125rem;
+		font-weight: 700;
+	}
+	.axomeme-header p {
+		margin: 0 0 1rem;
+		font-size: 0.875rem;
+		line-height: 1.5;
+		color: #475569;
+		max-width: 70ch;
+	}
+	.axomeme-summary {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+		gap: 0.75rem;
+		margin-bottom: 1rem;
+	}
+	.axomeme-stat {
+		background: #f8fafc;
+		border-radius: 0.375rem;
+		padding: 0.625rem 0.75rem;
+	}
+	.axomeme-stat strong {
+		display: block;
+		font-size: 1.5rem;
+		line-height: 1.1;
+	}
+	.axomeme-stat span {
+		font-size: 0.75rem;
+		color: #64748b;
+	}
+	.axomeme-controls {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 1rem;
+		margin-bottom: 0.5rem;
+		font-size: 0.875rem;
+	}
+	.axomeme-controls select {
+		margin-left: 0.375rem;
+		padding: 0.25rem 0.5rem;
+		border: 1px solid #cbd5e1;
+		border-radius: 0.25rem;
+	}
+	.axomeme-check {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+	}
+	.axomeme-plot-description {
+		font-size: 0.8125rem;
+		color: #475569;
+		line-height: 1.5;
+		max-width: 80ch;
+		margin: 0 0 0.5rem;
+	}
+	.axomeme-plot {
+		overflow-x: auto;
+		margin-bottom: 1rem;
+	}
+	.axomeme-table-wrap {
+		overflow-x: auto;
+	}
+	.axomeme-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 0.8125rem;
+	}
+	.axomeme-table th {
+		text-align: left;
+		padding: 0.5rem;
+		border-bottom: 1px solid #e2e8f0;
+		font-size: 0.6875rem;
+		text-transform: uppercase;
+		letter-spacing: 0.03em;
+		color: #64748b;
+		cursor: pointer;
+		white-space: nowrap;
+	}
+	.axomeme-table td {
+		padding: 0.3rem 0.5rem;
+		border-bottom: 1px solid #f1f5f9;
+	}
+	.axomeme-table .num {
+		text-align: right;
+	}
+	.mono {
+		font-family: ui-monospace, monospace;
+	}
+	.unscored {
+		color: #94a3b8;
+		font-family: inherit;
+	}
+	.axomeme-call {
+		display: inline-block;
+		padding: 0.1rem 0.4rem;
+		border-radius: 0.25rem;
+		font-size: 0.75rem;
+		white-space: nowrap;
+	}
+	.axomeme-pagination {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		margin-top: 0.75rem;
+		font-size: 0.8125rem;
+		color: #475569;
+	}
+	.axomeme-pagination button {
+		padding: 0.25rem 0.75rem;
+		border: 1px solid #cbd5e1;
+		border-radius: 0.25rem;
+		background: white;
+		cursor: pointer;
+	}
+	.axomeme-pagination button:disabled {
+		opacity: 0.45;
+		cursor: default;
+	}
+	.axomeme-footer {
+		margin-top: 1rem;
+		padding-top: 0.75rem;
+		border-top: 1px solid #e2e8f0;
+		font-size: 0.75rem;
+		color: #64748b;
+	}
+</style>

--- a/src/lib/AxomemeVisualization.svelte
+++ b/src/lib/AxomemeVisualization.svelte
@@ -36,6 +36,13 @@
 	} from './utils/axomeme-plots.js';
 
 	export let data: AxomemeResult | null = null;
+	/**
+	 * Mark the results as coming from a model still under development.
+	 *
+	 * A prop rather than a hard-coded badge: this library should not assert the maturity of somebody
+	 * else's model, and the answer changes over time without this component changing at all.
+	 */
+	export let beta: boolean = false;
 	export let plotType: string = 'Ranked sites';
 	/** Show only sites the model called, which is what most readers want first. */
 	export let onlyCalled: boolean = true;
@@ -117,7 +124,16 @@
 {:else}
 	<div class="axomeme-visualization">
 		<header class="axomeme-header">
-			<h3>AxoMEME predictions</h3>
+			<h3>
+				AxoMEME predictions
+				{#if beta}
+					<span
+						class="axomeme-beta"
+						title="The underlying model is still under active development; results may change between releases."
+						>Beta</span
+					>
+				{/if}
+			</h3>
 			<p>
 				A neural model ranks the sites of this alignment by how MEME-like their signal looks. MEME
 				was not run. The score orders sites <em>within this alignment</em> and is not calibrated to
@@ -244,6 +260,22 @@
 		color: #64748b;
 		font-style: italic;
 	}
+	.axomeme-beta {
+		display: inline-flex;
+		align-items: center;
+		vertical-align: middle;
+		margin-left: 0.5rem;
+		padding: 2px 8px;
+		background: #ede9fe;
+		border: 1px solid #8b5cf6;
+		border-radius: 12px;
+		font-size: 11px;
+		font-weight: 500;
+		color: #5b21b6;
+		text-transform: uppercase;
+		letter-spacing: 0.025em;
+	}
+
 	.axomeme-header h3 {
 		margin: 0 0 0.25rem;
 		font-size: 1.125rem;

--- a/src/lib/AxomemeVisualization.test.ts
+++ b/src/lib/AxomemeVisualization.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import AxomemeVisualization from './AxomemeVisualization.svelte';
+import type { AxomemeSiteData } from './utils/axomeme-utils.js';
+
+// Observable Plot is exercised directly in axomeme-utils tests; here it is stubbed so a component
+// test never depends on SVG layout in jsdom.
+vi.mock('@observablehq/plot', () => {
+	const stub = () => ({});
+	return {
+		plot: vi.fn(() => {
+			const div = document.createElement('div');
+			div.innerHTML = '<svg><text>plot</text></svg>';
+			return div;
+		}),
+		dot: stub,
+		ruleY: stub,
+		ruleX: stub,
+		rectY: stub,
+		line: stub,
+		binX: stub
+	};
+});
+
+function site(i: number, over: Partial<AxomemeSiteData> = {}): AxomemeSiteData {
+	return {
+		site: i,
+		refCodon: 'ATG',
+		refAa: 'M',
+		isVariable: true,
+		lrt: i / 10,
+		logLrt: Math.log1p(i / 10),
+		alphaDs: 0.4,
+		betaPosDn: 1.1,
+		pPos: 0.9,
+		zScore: 0.5,
+		percentile: i,
+		call: 'Neutral',
+		...over
+	};
+}
+
+const result = {
+	modelVersion: '2.0-viral-finetuned',
+	sites: [
+		...Array.from({ length: 20 }, (_, i) => site(i + 1)),
+		site(21, { call: 'Top 5%', lrt: 3.0, percentile: 96 }),
+		site(22, { call: 'Top 2%', lrt: 4.0, percentile: 99 }),
+		site(23, { isVariable: false, lrt: 0, percentile: 0 })
+	],
+	summary: { callMode: 'percentile', referenceSequence: 'Human' }
+};
+
+describe('AxomemeVisualization', () => {
+	it('renders an empty state rather than a broken table when there is no data', () => {
+		render(AxomemeVisualization, { props: { data: null } });
+		expect(screen.getByText(/No AxoMEME results/i)).toBeInTheDocument();
+	});
+
+	it('renders without hanging', () => {
+		// This test exists because an earlier version froze the browser tab. Reactive statements that
+		// assign to a value other statements depend on can loop forever, and the symptom is a page that
+		// stops responding rather than an error — nothing in a normal assertion catches it.
+		const start = Date.now();
+		render(AxomemeVisualization, { props: { data: result } });
+		expect(screen.getByText('AxoMEME predictions')).toBeInTheDocument();
+		expect(Date.now() - start).toBeLessThan(5000);
+	});
+
+	it('says the score is not calibrated, in the copy a reader sees first', () => {
+		render(AxomemeVisualization, { props: { data: result } });
+		expect(screen.getByText(/not calibrated/i)).toBeInTheDocument();
+		expect(screen.getByText(/MEME was not run/i)).toBeInTheDocument();
+	});
+
+	it('counts only scored sites, and only called ones as top-ranked', () => {
+		const { container } = render(AxomemeVisualization, { props: { data: result } });
+		// Scoped to the summary strip: bare numbers also appear in the table, so getByText is ambiguous.
+		const stats = [...container.querySelectorAll('.axomeme-stat strong')].map((n) => n.textContent);
+		// 23 sites total, 22 scored (one invariant), 2 called.
+		expect(stats[0]).toBe('2'); // top-ranked
+		expect(stats[1]).toBe('22'); // scored
+		expect(stats[2]).toBe('23'); // total
+	});
+
+	it('shows the tier labels the calling mode produced, not a confidence word', () => {
+		render(AxomemeVisualization, { props: { data: result } });
+		expect(screen.getByText('Top 2%')).toBeInTheDocument();
+		expect(screen.getByText('Top 5%')).toBeInTheDocument();
+		expect(screen.queryByText(/Tier 1 \(High\)/)).not.toBeInTheDocument();
+	});
+
+	it('falls back to all scored sites when nothing was called', () => {
+		// An empty table reads as a failure rather than as a result.
+		const none = { ...result, sites: Array.from({ length: 5 }, (_, i) => site(i + 1)) };
+		render(AxomemeVisualization, { props: { data: none } });
+		expect(screen.getByText('AxoMEME predictions')).toBeInTheDocument();
+		expect(screen.getAllByText('Neutral').length).toBeGreaterThan(0);
+	});
+
+	it('marks an invariant site as not scored rather than showing it as zero', () => {
+		const withInvariant = {
+			...result,
+			sites: [site(1, { isVariable: false }), site(2, { call: 'Top 2%' })]
+		};
+		render(AxomemeVisualization, { props: { data: withInvariant, onlyCalled: false } });
+		expect(screen.getByText(/not scored/i)).toBeInTheDocument();
+	});
+});

--- a/src/lib/AxomemeVisualization.test.ts
+++ b/src/lib/AxomemeVisualization.test.ts
@@ -1,109 +1,131 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
-import AxomemeVisualization from './AxomemeVisualization.svelte';
-import type { AxomemeSiteData } from './utils/axomeme-utils.js';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/svelte";
+import AxomemeVisualization from "./AxomemeVisualization.svelte";
+import type { AxomemeSiteData } from "./utils/axomeme-utils.js";
 
 // Observable Plot is exercised directly in axomeme-utils tests; here it is stubbed so a component
 // test never depends on SVG layout in jsdom.
-vi.mock('@observablehq/plot', () => {
-	const stub = () => ({});
-	return {
-		plot: vi.fn(() => {
-			const div = document.createElement('div');
-			div.innerHTML = '<svg><text>plot</text></svg>';
-			return div;
-		}),
-		dot: stub,
-		ruleY: stub,
-		ruleX: stub,
-		rectY: stub,
-		line: stub,
-		binX: stub
-	};
+vi.mock("@observablehq/plot", () => {
+  const stub = () => ({});
+  return {
+    plot: vi.fn(() => {
+      const div = document.createElement("div");
+      div.innerHTML = "<svg><text>plot</text></svg>";
+      return div;
+    }),
+    dot: stub,
+    ruleY: stub,
+    ruleX: stub,
+    rectY: stub,
+    line: stub,
+    binX: stub,
+  };
 });
 
 function site(i: number, over: Partial<AxomemeSiteData> = {}): AxomemeSiteData {
-	return {
-		site: i,
-		refCodon: 'ATG',
-		refAa: 'M',
-		isVariable: true,
-		lrt: i / 10,
-		logLrt: Math.log1p(i / 10),
-		alphaDs: 0.4,
-		betaPosDn: 1.1,
-		pPos: 0.9,
-		zScore: 0.5,
-		percentile: i,
-		call: 'Neutral',
-		...over
-	};
+  return {
+    site: i,
+    refCodon: "ATG",
+    refAa: "M",
+    isVariable: true,
+    lrt: i / 10,
+    logLrt: Math.log1p(i / 10),
+    alphaDs: 0.4,
+    betaPosDn: 1.1,
+    pPos: 0.9,
+    zScore: 0.5,
+    percentile: i,
+    call: "Neutral",
+    ...over,
+  };
 }
 
 const result = {
-	modelVersion: '2.0-viral-finetuned',
-	sites: [
-		...Array.from({ length: 20 }, (_, i) => site(i + 1)),
-		site(21, { call: 'Top 5%', lrt: 3.0, percentile: 96 }),
-		site(22, { call: 'Top 2%', lrt: 4.0, percentile: 99 }),
-		site(23, { isVariable: false, lrt: 0, percentile: 0 })
-	],
-	summary: { callMode: 'percentile', referenceSequence: 'Human' }
+  modelVersion: "2.0-viral-finetuned",
+  sites: [
+    ...Array.from({ length: 20 }, (_, i) => site(i + 1)),
+    site(21, { call: "Top 5%", lrt: 3.0, percentile: 96 }),
+    site(22, { call: "Top 2%", lrt: 4.0, percentile: 99 }),
+    site(23, { isVariable: false, lrt: 0, percentile: 0 }),
+  ],
+  summary: { callMode: "percentile", referenceSequence: "Human" },
 };
 
-describe('AxomemeVisualization', () => {
-	it('renders an empty state rather than a broken table when there is no data', () => {
-		render(AxomemeVisualization, { props: { data: null } });
-		expect(screen.getByText(/No AxoMEME results/i)).toBeInTheDocument();
-	});
+describe("AxomemeVisualization", () => {
+  it("renders an empty state rather than a broken table when there is no data", () => {
+    render(AxomemeVisualization, { props: { data: null } });
+    expect(screen.getByText(/No AxoMEME results/i)).toBeInTheDocument();
+  });
 
-	it('renders without hanging', () => {
-		// This test exists because an earlier version froze the browser tab. Reactive statements that
-		// assign to a value other statements depend on can loop forever, and the symptom is a page that
-		// stops responding rather than an error — nothing in a normal assertion catches it.
-		const start = Date.now();
-		render(AxomemeVisualization, { props: { data: result } });
-		expect(screen.getByText('AxoMEME predictions')).toBeInTheDocument();
-		expect(Date.now() - start).toBeLessThan(5000);
-	});
+  it("renders without hanging", () => {
+    // This test exists because an earlier version froze the browser tab. Reactive statements that
+    // assign to a value other statements depend on can loop forever, and the symptom is a page that
+    // stops responding rather than an error — nothing in a normal assertion catches it.
+    const start = Date.now();
+    render(AxomemeVisualization, { props: { data: result } });
+    expect(screen.getByText("AxoMEME predictions")).toBeInTheDocument();
+    expect(Date.now() - start).toBeLessThan(5000);
+  });
 
-	it('says the score is not calibrated, in the copy a reader sees first', () => {
-		render(AxomemeVisualization, { props: { data: result } });
-		expect(screen.getByText(/not calibrated/i)).toBeInTheDocument();
-		expect(screen.getByText(/MEME was not run/i)).toBeInTheDocument();
-	});
+  it("says the score is not calibrated, in the copy a reader sees first", () => {
+    render(AxomemeVisualization, { props: { data: result } });
+    expect(screen.getByText(/not calibrated/i)).toBeInTheDocument();
+    expect(screen.getByText(/MEME was not run/i)).toBeInTheDocument();
+  });
 
-	it('counts only scored sites, and only called ones as top-ranked', () => {
-		const { container } = render(AxomemeVisualization, { props: { data: result } });
-		// Scoped to the summary strip: bare numbers also appear in the table, so getByText is ambiguous.
-		const stats = [...container.querySelectorAll('.axomeme-stat strong')].map((n) => n.textContent);
-		// 23 sites total, 22 scored (one invariant), 2 called.
-		expect(stats[0]).toBe('2'); // top-ranked
-		expect(stats[1]).toBe('22'); // scored
-		expect(stats[2]).toBe('23'); // total
-	});
+  it("counts only scored sites, and only called ones as top-ranked", () => {
+    const { container } = render(AxomemeVisualization, {
+      props: { data: result },
+    });
+    // Scoped to the summary strip: bare numbers also appear in the table, so getByText is ambiguous.
+    const stats = [...container.querySelectorAll(".axomeme-stat strong")].map(
+      (n) => n.textContent,
+    );
+    // 23 sites total, 22 scored (one invariant), 2 called.
+    expect(stats[0]).toBe("2"); // top-ranked
+    expect(stats[1]).toBe("22"); // scored
+    expect(stats[2]).toBe("23"); // total
+  });
 
-	it('shows the tier labels the calling mode produced, not a confidence word', () => {
-		render(AxomemeVisualization, { props: { data: result } });
-		expect(screen.getByText('Top 2%')).toBeInTheDocument();
-		expect(screen.getByText('Top 5%')).toBeInTheDocument();
-		expect(screen.queryByText(/Tier 1 \(High\)/)).not.toBeInTheDocument();
-	});
+  it("shows the tier labels the calling mode produced, not a confidence word", () => {
+    render(AxomemeVisualization, { props: { data: result } });
+    expect(screen.getByText("Top 2%")).toBeInTheDocument();
+    expect(screen.getByText("Top 5%")).toBeInTheDocument();
+    expect(screen.queryByText(/Tier 1 \(High\)/)).not.toBeInTheDocument();
+  });
 
-	it('falls back to all scored sites when nothing was called', () => {
-		// An empty table reads as a failure rather than as a result.
-		const none = { ...result, sites: Array.from({ length: 5 }, (_, i) => site(i + 1)) };
-		render(AxomemeVisualization, { props: { data: none } });
-		expect(screen.getByText('AxoMEME predictions')).toBeInTheDocument();
-		expect(screen.getAllByText('Neutral').length).toBeGreaterThan(0);
-	});
+  it("marks results as Beta only when asked to", () => {
+    // A prop rather than a hard-coded badge: this library should not assert the maturity of
+    // somebody else's model, and the answer changes over time without this component changing.
+    const plain = render(AxomemeVisualization, { props: { data: result } });
+    expect(plain.queryByText("Beta")).not.toBeInTheDocument();
+    plain.unmount();
 
-	it('marks an invariant site as not scored rather than showing it as zero', () => {
-		const withInvariant = {
-			...result,
-			sites: [site(1, { isVariable: false }), site(2, { call: 'Top 2%' })]
-		};
-		render(AxomemeVisualization, { props: { data: withInvariant, onlyCalled: false } });
-		expect(screen.getByText(/not scored/i)).toBeInTheDocument();
-	});
+    const flagged = render(AxomemeVisualization, {
+      props: { data: result, beta: true },
+    });
+    expect(flagged.getByText("Beta")).toBeInTheDocument();
+  });
+
+  it("falls back to all scored sites when nothing was called", () => {
+    // An empty table reads as a failure rather than as a result.
+    const none = {
+      ...result,
+      sites: Array.from({ length: 5 }, (_, i) => site(i + 1)),
+    };
+    render(AxomemeVisualization, { props: { data: none } });
+    expect(screen.getByText("AxoMEME predictions")).toBeInTheDocument();
+    expect(screen.getAllByText("Neutral").length).toBeGreaterThan(0);
+  });
+
+  it("marks an invariant site as not scored rather than showing it as zero", () => {
+    const withInvariant = {
+      ...result,
+      sites: [site(1, { isVariable: false }), site(2, { call: "Top 2%" })],
+    };
+    render(AxomemeVisualization, {
+      props: { data: withInvariant, onlyCalled: false },
+    });
+    expect(screen.getByText(/not scored/i)).toBeInTheDocument();
+  });
 });

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -14,6 +14,7 @@ export { default as FubarVisualization } from './FubarVisualization.svelte';
 export { default as MultiHitVisualization } from './MultiHitVisualization.svelte';
 export { default as PhylogeneticTreeViewer } from './PhylogeneticTreeViewer.svelte';
 export { default as PrimeVisualization } from './PrimeVisualization.svelte';
+export { default as AxomemeVisualization } from './AxomemeVisualization.svelte';
 
 // Export utilities
 export * from './utils/fel-plots.js';
@@ -26,6 +27,8 @@ export * from './utils/fubar-plots.js';
 export * from './utils/multi-hit-utils.js';
 export * from './utils/prime-utils.js';
 export * from './utils/prime-plots.js';
+export * from './utils/axomeme-utils.js';
+export * from './utils/axomeme-plots.js';
 
 // Data utilities
 export { loadDataFromUrl, loadDataFromStorage, getTestData } from './data/data-loader.js';

--- a/src/lib/utils/axomeme-plots.ts
+++ b/src/lib/utils/axomeme-plots.ts
@@ -1,0 +1,211 @@
+/**
+ * axomeme-plots.ts — Observable Plot specs for AxoMEME results.
+ *
+ * ONE RULE GOVERNS ALL OF THESE: no threshold line. Every other per-site plot in this library draws a
+ * rule at the significance cutoff, because for a real likelihood ratio test that line means
+ * something. AxoMEME's score is not calibrated to that scale — across 12 real DataMonkey submissions
+ * and 662 variable sites it reached the p <= 0.10 gate once and the p <= 0.05 gate never, on data
+ * where MEME itself reports significant sites. A horizontal rule here would be read as significance
+ * and would be wrong. What the model provides is an ORDER, so these plots show position within that
+ * order and let the tier colours carry the calling.
+ *
+ * Invariant sites are excluded upstream by getScoredSites(); their zeros were never predictions.
+ */
+
+import * as Plot from '@observablehq/plot';
+import {
+	AXOMEME_COLORS,
+	AXOMEME_NEUTRAL_CALL,
+	assignTiers,
+	getScoredSites,
+	type AxomemeSiteData
+} from './axomeme-utils.js';
+
+interface PlotOption {
+	label: string;
+	available: (sites: AxomemeSiteData[]) => boolean;
+}
+
+export function getAxomemePlotOptions(): PlotOption[] {
+	return [
+		{ label: 'Ranked sites', available: () => true },
+		{ label: 'Score by site', available: () => true },
+		{ label: 'Rank distribution', available: (s) => getScoredSites(s).length >= 5 },
+		{ label: 'Synonymous vs non-synonymous', available: (s) => getScoredSites(s).length > 0 }
+	];
+}
+
+export function getAxomemePlotDescription(plotType: string): string {
+	const d: Record<string, string> = {
+		'Ranked sites':
+			'Every scored site, ordered by the model’s score. The x-axis is rank within this alignment, not codon position — it shows how sharply the top sites separate from the rest. A long flat tail means the model found little to distinguish.',
+		'Score by site':
+			'The model’s score along the coding sequence. Position on the y-axis is meaningful only relative to the other sites in this same alignment; the value is not calibrated to MEME’s scale and no significance threshold is drawn, because none would be meaningful.',
+		'Rank distribution':
+			'How the scores are spread across scored sites. A distribution with a clear right tail is one where the ranking is informative; a narrow one means the top-ranked sites are barely separated from the rest and the ordering carries little signal.',
+		'Synonymous vs non-synonymous':
+			'Predicted synonymous (dS) against non-synonymous (dN⁺) rate per site. Points above the diagonal have dN⁺ > dS, the pattern associated with positive selection. These are model estimates, not fitted rates.'
+	};
+	return d[plotType] ?? '';
+}
+
+/** Shared legend so tier colours mean the same thing in every plot. */
+function tierLegend(sites: AxomemeSiteData[]) {
+	const tiers = assignTiers(sites);
+	const labels = [...tiers.entries()].sort((a, b) => a[1] - b[1]).map(([label]) => label);
+	return {
+		domain: [...labels, AXOMEME_NEUTRAL_CALL],
+		range: [
+			...labels.map((l) =>
+				tiers.get(l) === 1 ? AXOMEME_COLORS.tier1 : AXOMEME_COLORS.tier2
+			),
+			AXOMEME_COLORS.neutral
+		]
+	};
+}
+
+/**
+ * Sites ordered by score — the plot that actually matches what the model does.
+ *
+ * A Manhattan plot along the sequence answers "where are the significant sites"; this answers "how
+ * strongly does the ranking separate anything", which is the question a ranker can support.
+ */
+export function createAxomemeRankPlot(sites: AxomemeSiteData[]): any {
+	const scored = getScoredSites(sites);
+	const legend = tierLegend(sites);
+	const ranked = [...scored]
+		.sort((a, b) => b.lrt - a.lrt)
+		.map((s, i) => ({ ...s, rank: i + 1 }));
+
+	return Plot.plot({
+		width: 800,
+		height: 320,
+		marginBottom: 44,
+		marginLeft: 56,
+		x: { label: 'Rank within this alignment →', grid: true },
+		y: { label: '↑ Score (uncalibrated)', grid: true, zero: true },
+		color: { ...legend, legend: true },
+		marks: [
+			Plot.ruleY([0], { stroke: '#e2e8f0' }),
+			Plot.dot(ranked, {
+				x: 'rank',
+				y: 'lrt',
+				fill: 'call',
+				r: 3.2,
+				title: (d: any) =>
+					`Site ${d.site} (${d.refCodon}/${d.refAa})\nrank ${d.rank} of ${ranked.length}\nscore ${d.lrt.toFixed(3)}\npercentile ${d.percentile.toFixed(1)}\n${d.call}`
+			})
+		]
+	});
+}
+
+/**
+ * Score along the coding sequence.
+ *
+ * The familiar per-site view, deliberately WITHOUT a threshold rule. Only scored sites appear, so
+ * gaps in the x-axis are invariant columns rather than missing data.
+ */
+export function createAxomemeSitePlot(sites: AxomemeSiteData[]): any {
+	const scored = getScoredSites(sites);
+	const legend = tierLegend(sites);
+
+	return Plot.plot({
+		width: 800,
+		height: 320,
+		marginBottom: 44,
+		marginLeft: 56,
+		x: { label: 'Codon site →', grid: true },
+		y: { label: '↑ Score (uncalibrated)', grid: true, zero: true },
+		color: { ...legend, legend: true },
+		marks: [
+			Plot.ruleY([0], { stroke: '#e2e8f0' }),
+			Plot.ruleX(scored, {
+				x: 'site',
+				y1: 0,
+				y2: 'lrt',
+				stroke: '#e2e8f0',
+				strokeWidth: 1
+			}),
+			Plot.dot(scored, {
+				x: 'site',
+				y: 'lrt',
+				fill: 'call',
+				r: 3.2,
+				title: (d: any) =>
+					`Site ${d.site} (${d.refCodon}/${d.refAa})\nscore ${d.lrt.toFixed(3)}\npercentile ${d.percentile.toFixed(1)}\n${d.call}`
+			})
+		]
+	});
+}
+
+/** How spread out the scores are — a narrow distribution means the ranking carries little. */
+export function createAxomemeDistributionPlot(sites: AxomemeSiteData[]): any {
+	const scored = getScoredSites(sites);
+	return Plot.plot({
+		width: 800,
+		height: 280,
+		marginBottom: 44,
+		marginLeft: 56,
+		x: { label: 'Score (uncalibrated) →', grid: true },
+		y: { label: '↑ Sites', grid: true },
+		marks: [
+			// fill belongs to the MARK, not to the bin transform's inputs — binX only accepts channel
+			// definitions, and passing a constant colour through it is a type error.
+			Plot.rectY(scored, {
+				...Plot.binX({ y: 'count' }, { x: 'lrt' }),
+				fill: AXOMEME_COLORS.tier2
+			}),
+			Plot.ruleY([0])
+		]
+	});
+}
+
+/** dS against dN+, with the neutral diagonal for reference. */
+export function createAxomemeRatePlot(sites: AxomemeSiteData[]): any {
+	const scored = getScoredSites(sites);
+	const legend = tierLegend(sites);
+	const max = Math.max(1, ...scored.map((s) => Math.max(s.alphaDs, s.betaPosDn)));
+
+	return Plot.plot({
+		width: 800,
+		height: 400,
+		marginBottom: 44,
+		marginLeft: 56,
+		x: { label: 'Synonymous rate (dS) →', grid: true, domain: [0, max] },
+		y: { label: '↑ Non-synonymous rate (dN⁺)', grid: true, domain: [0, max] },
+		color: { ...legend, legend: true },
+		marks: [
+			// dN = dS. Above it, dN+ exceeds dS — the positive-selection pattern.
+			Plot.line(
+				[
+					{ x: 0, y: 0 },
+					{ x: max, y: max }
+				],
+				{ x: 'x', y: 'y', stroke: '#cbd5e1', strokeDasharray: '4,4' }
+			),
+			Plot.dot(scored, {
+				x: 'alphaDs',
+				y: 'betaPosDn',
+				fill: 'call',
+				r: 3.2,
+				title: (d: any) =>
+					`Site ${d.site} (${d.refCodon}/${d.refAa})\ndS ${d.alphaDs.toFixed(3)}\ndN⁺ ${d.betaPosDn.toFixed(3)}\n${d.call}`
+			})
+		]
+	});
+}
+
+/** Dispatch by plot label. */
+export function createAxomemePlot(plotType: string, sites: AxomemeSiteData[]): any {
+	switch (plotType) {
+		case 'Score by site':
+			return createAxomemeSitePlot(sites);
+		case 'Rank distribution':
+			return createAxomemeDistributionPlot(sites);
+		case 'Synonymous vs non-synonymous':
+			return createAxomemeRatePlot(sites);
+		case 'Ranked sites':
+		default:
+			return createAxomemeRankPlot(sites);
+	}
+}

--- a/src/lib/utils/axomeme-utils.ts
+++ b/src/lib/utils/axomeme-utils.ts
@@ -1,0 +1,172 @@
+/**
+ * axomeme-utils.ts — data shaping for AxoMEME results.
+ *
+ * AxoMEME is not a HyPhy analysis. It is a neural surrogate that RANKS the sites of an alignment by
+ * how MEME-like their selection signal looks, and it emits per-site predictions rather than a HyPhy
+ * results document. Two consequences run through everything here:
+ *
+ *   1. THE SCORE IS NOT CALIBRATED. Measured across 12 real DataMonkey submissions and 662 variable
+ *      sites, the model's predicted LRT reached the chi-square gate for p <= 0.10 exactly once, and
+ *      never reached the one for p <= 0.05 — including on an alignment where MEME itself reports 17
+ *      significant sites. The model's authors report Spearman rank correlation, not calibration. So
+ *      these plots present RANK and never draw a significance threshold line: there is no threshold
+ *      on this scale that means what a reader would assume it means.
+ *   2. INVARIANT SITES ARE NOT SCORED. A site with no amino-acid variation is zeroed before the model
+ *      is consulted, so its zero means "not applicable" rather than "no selection". Those sites are
+ *      excluded from every plot and every statistic; including them would pull the whole distribution
+ *      toward zero and make the ranking meaningless.
+ */
+
+/** One row of AxoMEME's per-site output. */
+export interface AxomemeSiteData {
+	/** 1-indexed codon site. */
+	site: number;
+	/** Reference sequence's codon at this site. */
+	refCodon: string;
+	/** Its translation, or '?' where the codon is gapped or ambiguous. */
+	refAa: string;
+	/** False when no amino-acid variation exists — the site is not scored at all. */
+	isVariable: boolean;
+	/** The model's score. Named for what it predicts, but NOT on MEME's calibrated scale. */
+	lrt: number;
+	/** log1p(lrt). Derived, not a separate prediction. */
+	logLrt: number;
+	/** Synonymous rate estimate. */
+	alphaDs: number;
+	/** Non-synonymous rate estimate for the positive class. */
+	betaPosDn: number;
+	/** Probability of the positive-selection class. */
+	pPos: number;
+	/** Score relative to this alignment's variable sites. */
+	zScore: number;
+	/** Percentile rank within this alignment's variable sites. */
+	percentile: number;
+	/** The tier label, phrased as the rule that produced it (e.g. "Top 2%"). */
+	call: string;
+}
+
+/** The result object AxoMEME produces. */
+export interface AxomemeResult {
+	method?: string;
+	modelVersion?: string;
+	modelSha256?: string;
+	isSurrogate?: boolean;
+	surrogateFor?: string;
+	sites: AxomemeSiteData[];
+	summary?: Record<string, any>;
+}
+
+/**
+ * Colours for the three tiers.
+ *
+ * Deliberately NOT the red/green of a significance test. These encode rank position, and a palette
+ * borrowed from p-value plots would imply the calibration the model does not have. Ordered so that
+ * higher rank reads as warmer without either extreme looking like a verdict.
+ */
+export const AXOMEME_COLORS = {
+	tier1: '#b45309',
+	tier2: '#d97706',
+	neutral: '#94a3b8',
+	unscored: '#e2e8f0'
+} as const;
+
+export const AXOMEME_NEUTRAL_CALL = 'Neutral';
+
+/**
+ * Normalise a call label to a tier number: 1 (strictest), 2, or 0 for neutral.
+ *
+ * Labels are not fixed strings. AxoMEME names each tier after the rule that produced it, so the same
+ * result can be labelled "Top 2%", "Z >= 2.5" or "LRT >= 4.45" depending on the calling mode the user
+ * chose. Matching literal text would break the moment a threshold is adjusted.
+ *
+ * Instead the distinct non-neutral labels are ordered by the LOWEST score they contain: the stricter
+ * tier necessarily has a higher floor, whichever rule produced it. That holds for all three modes and
+ * needs no knowledge of which one ran.
+ */
+export function assignTiers(sites: AxomemeSiteData[]): Map<string, number> {
+	const floors = new Map<string, number>();
+	for (const s of sites) {
+		if (!s.isVariable || s.call === AXOMEME_NEUTRAL_CALL) continue;
+		const prev = floors.get(s.call);
+		if (prev === undefined || s.lrt < prev) floors.set(s.call, s.lrt);
+	}
+	const ordered = [...floors.entries()].sort((a, b) => b[1] - a[1]).map(([label]) => label);
+	const tiers = new Map<string, number>();
+	ordered.forEach((label, i) => tiers.set(label, i + 1));
+	return tiers;
+}
+
+/** Colour for a row, by tier rather than by label text. */
+export function getAxomemeColor(site: AxomemeSiteData, tiers: Map<string, number>): string {
+	if (!site.isVariable) return AXOMEME_COLORS.unscored;
+	const tier = tiers.get(site.call);
+	if (tier === 1) return AXOMEME_COLORS.tier1;
+	if (tier === 2) return AXOMEME_COLORS.tier2;
+	return AXOMEME_COLORS.neutral;
+}
+
+/**
+ * Sites that the model actually scored.
+ *
+ * Every plot and every summary statistic uses this rather than the full list. An invariant site
+ * carries a hard zero that was never a prediction, and mixing those into a rank distribution makes
+ * the ranking mean something else.
+ */
+export function getScoredSites(sites: AxomemeSiteData[]): AxomemeSiteData[] {
+	return (sites ?? []).filter((s) => s.isVariable);
+}
+
+export interface AxomemeAttributes {
+	totalSites: number;
+	scoredSites: number;
+	calledSites: number;
+	tierCounts: Record<string, number>;
+	maxScore: number;
+	medianScore: number;
+	callMode: string | null;
+	modelVersion: string | null;
+	referenceSequence: string | null;
+}
+
+/** Headline numbers for the summary strip. */
+export function getAxomemeAttributes(result: AxomemeResult | null): AxomemeAttributes {
+	const sites = result?.sites ?? [];
+	const scored = getScoredSites(sites);
+	const called = scored.filter((s) => s.call !== AXOMEME_NEUTRAL_CALL);
+	const tierCounts: Record<string, number> = {};
+	for (const s of called) tierCounts[s.call] = (tierCounts[s.call] ?? 0) + 1;
+
+	const values = scored.map((s) => s.lrt).sort((a, b) => a - b);
+	const median = values.length
+		? values.length % 2
+			? values[(values.length - 1) / 2]
+			: (values[values.length / 2 - 1] + values[values.length / 2]) / 2
+		: 0;
+
+	return {
+		totalSites: sites.length,
+		scoredSites: scored.length,
+		calledSites: called.length,
+		tierCounts,
+		maxScore: values.length ? values[values.length - 1] : 0,
+		medianScore: median,
+		callMode: result?.summary?.callMode ?? null,
+		modelVersion: result?.modelVersion ?? null,
+		referenceSequence: result?.summary?.referenceSequence ?? null
+	};
+}
+
+/** Table rows, sorted by the requested column. */
+export function sortAxomemeSites(
+	sites: AxomemeSiteData[],
+	column: keyof AxomemeSiteData,
+	direction: 'asc' | 'desc'
+): AxomemeSiteData[] {
+	const sign = direction === 'asc' ? 1 : -1;
+	return [...sites].sort((a, b) => {
+		const av = a[column];
+		const bv = b[column];
+		if (typeof av === 'number' && typeof bv === 'number') return (av - bv) * sign;
+		return String(av).localeCompare(String(bv)) * sign;
+	});
+}

--- a/src/routes/axomeme/+page.svelte
+++ b/src/routes/axomeme/+page.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	/**
+	 * Development page for AxomemeVisualization.
+	 *
+	 * Matches the other per-method routes in this app: synthetic data, every plot reachable, no
+	 * network. It exists because the component's failure modes are browser-only — Observable Plot
+	 * renders nothing meaningful under jsdom, so a component test can pass while the real thing
+	 * misbehaves in a way only a browser shows.
+	 */
+	import { AxomemeVisualization } from '$lib/index.js';
+
+	/** Deterministic synthetic sites: no random, so a visual regression is a real change. */
+	function makeSites(n: number) {
+		const sites = [];
+		for (let i = 1; i <= n; i++) {
+			// Every fifth site is invariant, which is roughly the real proportion and exercises the
+			// "not scored" row.
+			const isVariable = i % 5 !== 0;
+			const score = isVariable ? ((i * 37) % 100) / 33 : 0;
+			const pct = isVariable ? ((i * 37) % 100) : 0;
+			sites.push({
+				site: i,
+				refCodon: ['ATG', 'TTA', 'GGC', 'AAA', 'TCA'][i % 5],
+				refAa: ['M', 'L', 'G', 'K', 'S'][i % 5],
+				isVariable,
+				lrt: score,
+				logLrt: Math.log1p(score),
+				alphaDs: isVariable ? ((i * 13) % 50) / 25 : 0,
+				betaPosDn: isVariable ? ((i * 7) % 60) / 20 : 0,
+				pPos: isVariable ? 0.5 + ((i * 11) % 50) / 100 : 0,
+				zScore: isVariable ? (score - 1.5) / 0.8 : 0,
+				percentile: pct,
+				call: !isVariable ? 'Neutral' : pct >= 98 ? 'Top 2%' : pct >= 95 ? 'Top 5%' : 'Neutral'
+			});
+		}
+		return sites;
+	}
+
+	let siteCount = 200;
+	$: data = {
+		method: 'AxoMEME',
+		modelVersion: '2.0-viral-finetuned',
+		isSurrogate: true,
+		surrogateFor: 'MEME',
+		sites: makeSites(siteCount),
+		summary: { callMode: 'percentile', referenceSequence: 'synthetic_ref' }
+	};
+</script>
+
+<svelte:head><title>AxoMEME — hyphy-scope</title></svelte:head>
+
+<main>
+	<h1>AxoMEME visualization</h1>
+	<label>
+		Sites
+		<input type="range" min="10" max="2000" step="10" bind:value={siteCount} />
+		{siteCount}
+	</label>
+	<hr />
+	<AxomemeVisualization {data} />
+</main>
+
+<style>
+	main {
+		max-width: 900px;
+		margin: 2rem auto;
+		padding: 0 1rem;
+		font-family: ui-sans-serif, system-ui, sans-serif;
+	}
+	label {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.875rem;
+		margin-bottom: 1rem;
+	}
+	hr {
+		border: none;
+		border-top: 1px solid #e2e8f0;
+		margin: 1rem 0 1.5rem;
+	}
+</style>


### PR DESCRIPTION
## What this adds

`AxomemeVisualization`, plus `axomeme-utils.ts` and `axomeme-plots.ts`, following the existing
`{method}-utils` / `{method}-plots` / component pattern.

AxoMEME is a neural surrogate that **ranks** the sites of an alignment by how MEME-like their
selection signal looks. It is not a HyPhy analysis, and that difference drives every design decision
here.

## Why this component breaks the library's conventions

Its score is **not calibrated to MEME's scale**. Measured across 12 real DataMonkey submissions and
662 variable sites:

| | |
| :--- | ---: |
| highest predicted LRT anywhere | 3.902 |
| sites clearing the p ≤ 0.10 gate (3.12) | 1 of 662 |
| sites clearing the p ≤ 0.05 gate (4.45) | 0 of 662 |

On an alignment where MEME itself reports 17 sites at p ≤ 0.05, the model's maximum was 2.484. The
model's authors report Spearman rank correlation, not calibration — and rank correlation can be good
while absolute scale is off by a factor of two.

So, deliberately unlike every other visualisation here:

- **No threshold line, anywhere, and no threshold control.** Every other per-site plot draws a rule at
  the significance cutoff because for a real likelihood ratio test that line means something. Here it
  would be read as significance and would be wrong.
- **The default plot orders by rank, not codon position.** "How sharply do the top sites separate" is
  a question a ranker can answer; "where are the significant sites" is not.
- **The score column is labelled `Score`, not `LRT`.** Calling it an LRT invites a comparison against
  chi-square thresholds it clears once in 662 sites.
- **Tier labels are derived, not matched.** AxoMEME names each tier after the rule that produced it
  (`Top 2%`, `Z ≥ 2.5`, `LRT ≥ 4.45`), so tiers are assigned by ordering the distinct labels by the
  lowest score each contains. That holds for every calling mode without knowing which one ran.
- **Invariant sites read "not scored"** rather than `0.000`. Those zeros are set before the model is
  consulted; showing them as values conflates "the model said nothing" with "we never asked".

## Plots

Ranked sites (default), score by site, score distribution, and dS vs dN⁺ with the neutral diagonal.

## One bug worth reading about

`renderPlot` is deliberately **synchronous**, and the comment on it explains why at length.

An earlier version awaited `tick()` first, to be sure the container was bound. `tick()` flushes
pending effects — including the reactive statement that called it — which called `renderPlot` again,
which awaited `tick()` again. The recursion killed the renderer process with **no console error, no
page error and no stack**. Every other route in the dev app loaded fine, which made it look like a
build or link problem rather than a component one.

The await bought nothing: `bind:this` is assigned before the effect runs.

## Testing

- 7 component tests (`AxomemeVisualization.test.ts`), including one asserting the component mounts
  without hanging, since that failure mode produces no error to assert on.
- `src/routes/axomeme` — a dev page matching the other per-method routes. It exists because the bug
  above is **browser-only**: Observable Plot renders nothing meaningful under jsdom, so the component
  tests passed throughout.
- `svelte-check` clean for the new files.

## Note for the consumer

DataMonkey3 uses this via `npm link` today. It needs a version bump and publish before DataMonkey3's
matching PR can drop its link.
